### PR TITLE
Added style picker according to state priority on lifts

### DIFF
--- a/packages/dashboard/src/components/schedule-visualizer/lift-overlay.tsx
+++ b/packages/dashboard/src/components/schedule-visualizer/lift-overlay.tsx
@@ -1,13 +1,36 @@
 import * as RomiCore from '@osrf/romi-js-core-interfaces';
 import Debug from 'debug';
 import React, { useContext } from 'react';
-import { LiftMarker as LiftMarker_, LiftMarkerProps } from 'react-components';
+import { LiftMarker as LiftMarker_, LiftMarkerProps, useLiftMarkerStyles } from 'react-components';
 import { viewBoxFromLeafletBounds } from '../../util/css-utils';
 import { LiftStateContext } from '../rmf-contexts';
 import SVGOverlay, { SVGOverlayProps } from './svg-overlay';
 
 const debug = Debug('ScheduleVisualizer:LiftsOverlay');
 const LiftMarker = React.memo(LiftMarker_);
+
+const getLiftModeVariant = (
+  currentFloor: string,
+  liftState?: RomiCore.LiftState,
+): keyof ReturnType<typeof useLiftMarkerStyles> | undefined => {
+  if (!liftState) return 'unknown';
+
+  const liftMode = liftState.current_mode;
+
+  if (liftMode === RomiCore.LiftState.MODE_FIRE) return 'fire';
+  if (liftMode === RomiCore.LiftState.MODE_EMERGENCY) return 'emergency';
+  if (liftMode === RomiCore.LiftState.MODE_OFFLINE) return 'offLine';
+  if (liftState.current_floor === currentFloor) {
+    if (liftMode === RomiCore.LiftState.MODE_HUMAN) return 'human';
+    if (liftMode === RomiCore.LiftState.MODE_AGV) return 'onCurrentFloor';
+  } else {
+    if (liftMode === RomiCore.LiftState.MODE_HUMAN) return 'moving';
+    if (liftMode === RomiCore.LiftState.MODE_AGV) return 'moving';
+  }
+  if (liftMode === RomiCore.LiftState.MODE_UNKNOWN) return 'unknown';
+
+  return 'unknown';
+};
 
 export interface LiftsOverlayProps extends SVGOverlayProps {
   currentFloor: string;
@@ -38,6 +61,7 @@ export const LiftsOverlay = (props: LiftsOverlayProps) => {
               lift={lift}
               onClick={handleLiftClick}
               liftState={liftsState && liftsState[lift.name]}
+              variant={liftsState && getLiftModeVariant(currentFloor, liftsState[lift.name])}
             />
           ))}
         </svg>

--- a/packages/dashboard/src/components/schedule-visualizer/lift-overlay.tsx
+++ b/packages/dashboard/src/components/schedule-visualizer/lift-overlay.tsx
@@ -9,25 +9,23 @@ import SVGOverlay, { SVGOverlayProps } from './svg-overlay';
 const debug = Debug('ScheduleVisualizer:LiftsOverlay');
 const LiftMarker = React.memo(LiftMarker_);
 
-const getLiftModeVariant = (
+export const getLiftModeVariant = (
   currentFloor: string,
-  liftState?: RomiCore.LiftState,
+  liftStateMode?: number,
+  liftStateFloor?: string,
 ): keyof ReturnType<typeof useLiftMarkerStyles> | undefined => {
-  if (!liftState) return 'unknown';
-
-  const liftMode = liftState.current_mode;
-
-  if (liftMode === RomiCore.LiftState.MODE_FIRE) return 'fire';
-  if (liftMode === RomiCore.LiftState.MODE_EMERGENCY) return 'emergency';
-  if (liftMode === RomiCore.LiftState.MODE_OFFLINE) return 'offLine';
-  if (liftState.current_floor === currentFloor) {
-    if (liftMode === RomiCore.LiftState.MODE_HUMAN) return 'human';
-    if (liftMode === RomiCore.LiftState.MODE_AGV) return 'onCurrentFloor';
+  if (!liftStateMode && !liftStateFloor) return 'unknown';
+  if (liftStateMode === RomiCore.LiftState.MODE_FIRE) return 'fire';
+  if (liftStateMode === RomiCore.LiftState.MODE_EMERGENCY) return 'emergency';
+  if (liftStateMode === RomiCore.LiftState.MODE_OFFLINE) return 'offLine';
+  if (liftStateFloor === currentFloor) {
+    if (liftStateMode === RomiCore.LiftState.MODE_HUMAN) return 'human';
+    if (liftStateMode === RomiCore.LiftState.MODE_AGV) return 'onCurrentFloor';
   } else {
-    if (liftMode === RomiCore.LiftState.MODE_HUMAN) return 'moving';
-    if (liftMode === RomiCore.LiftState.MODE_AGV) return 'moving';
+    if (liftStateMode === RomiCore.LiftState.MODE_HUMAN) return 'moving';
+    if (liftStateMode === RomiCore.LiftState.MODE_AGV) return 'moving';
   }
-  if (liftMode === RomiCore.LiftState.MODE_UNKNOWN) return 'unknown';
+  if (liftStateMode === RomiCore.LiftState.MODE_UNKNOWN) return 'unknown';
 
   return 'unknown';
 };
@@ -61,7 +59,14 @@ export const LiftsOverlay = (props: LiftsOverlayProps) => {
               lift={lift}
               onClick={handleLiftClick}
               liftState={liftsState && liftsState[lift.name]}
-              variant={liftsState && getLiftModeVariant(currentFloor, liftsState[lift.name])}
+              variant={
+                liftsState &&
+                getLiftModeVariant(
+                  currentFloor,
+                  liftsState[lift.name]?.current_mode,
+                  liftsState[lift.name]?.current_floor,
+                )
+              }
             />
           ))}
         </svg>

--- a/packages/dashboard/src/components/schedule-visualizer/tests/lifts-overlay.test.tsx
+++ b/packages/dashboard/src/components/schedule-visualizer/tests/lifts-overlay.test.tsx
@@ -1,20 +1,63 @@
-import { mount } from 'enzyme';
+import { render } from '@testing-library/react';
 import L from 'leaflet';
 import React from 'react';
-import { LiftMarker } from 'react-components';
+import * as RomiCore from '@osrf/romi-js-core-interfaces';
 import { Map as LMap } from 'react-leaflet';
 import officeMap from '../../../mock/data/building-map-office';
-import LiftsOverlay from '../lift-overlay';
+import LiftsOverlay, { getLiftModeVariant } from '../lift-overlay';
 
-test('Render lifts correctly', () => {
-  const lifts = officeMap.lifts;
-  const bounds = new L.LatLngBounds([0, 25.7], [-14, 0]);
-  const wrapper = mount(
-    <LMap>
-      <LiftsOverlay currentFloor={'L1'} bounds={bounds} lifts={lifts} />
-    </LMap>,
-  );
-  expect(wrapper.find(LiftMarker).length).toBe(officeMap.lifts.length);
+function getLift() {
+  return officeMap.lifts;
+}
 
-  wrapper.unmount();
+describe('Lift render', () => {
+  test('smoke test', () => {
+    const lifts = getLift();
+    const bounds = new L.LatLngBounds([0, 25.7], [-14, 0]);
+    render(
+      <LMap>
+        <LiftsOverlay currentFloor={'L1'} bounds={bounds} lifts={lifts} />
+      </LMap>,
+    );
+  });
+});
+
+describe('picks style in correct order', () => {
+  test('Returns unknown if liftStateMode and liftStateMode are undefined ', () => {
+    expect(getLiftModeVariant('L1')).toBe('unknown');
+  });
+
+  test('picks emergency and fire mode if the lift is on the current floor and on a different floor', () => {
+    const modeFire = getLiftModeVariant('L1', RomiCore.LiftState.MODE_FIRE, 'L1');
+    expect(modeFire).toBe('fire');
+
+    const modeEmergency = getLiftModeVariant('L1', RomiCore.LiftState.MODE_EMERGENCY, 'L2');
+    expect(modeEmergency).toBe('emergency');
+  });
+
+  test('picks `offline` mode if the lift is on the current floor and a different floor', () => {
+    const modeOfflineOnFloor = getLiftModeVariant('L1', RomiCore.LiftState.MODE_OFFLINE, 'L1');
+    expect(modeOfflineOnFloor).toBe('offLine');
+
+    const modeOfflineOnAnotherFloor = getLiftModeVariant(
+      'L1',
+      RomiCore.LiftState.MODE_OFFLINE,
+      'L2',
+    );
+    expect(modeOfflineOnAnotherFloor).toBe('offLine');
+  });
+
+  test('picks `moving` mode if the lift is on a different floor', () => {
+    const modeMovingAgv = getLiftModeVariant('L1', RomiCore.LiftState.MODE_AGV, 'L2');
+    expect(modeMovingAgv).toBe('moving');
+    const modeMovingHuman = getLiftModeVariant('L1', RomiCore.LiftState.MODE_HUMAN, 'L2');
+    expect(modeMovingHuman).toBe('moving');
+  });
+
+  test('picks AGV and HUMAN mode if the lift is on the same floor ', () => {
+    const modeAgv = getLiftModeVariant('L1', RomiCore.LiftState.MODE_AGV, 'L1');
+    const modeHuman = getLiftModeVariant('L1', RomiCore.LiftState.MODE_HUMAN, 'L1');
+    expect(modeAgv).toBe('onCurrentFloor');
+    expect(modeHuman).toBe('human');
+  });
 });

--- a/packages/react-components/lib/lifts/lift-marker.tsx
+++ b/packages/react-components/lib/lifts/lift-marker.tsx
@@ -56,7 +56,7 @@ const useStyles = makeStyles({
   },
 });
 
-const useMarkerStyles = makeStyles({
+export const useLiftMarkerStyles = makeStyles({
   onCurrentFloor: {
     fill: 'green',
     opacity: '70%',
@@ -103,7 +103,7 @@ export interface LiftMarkerProps extends Omit<React.SVGProps<SVGGElement>, 'onCl
    * default: true
    */
   translate?: boolean;
-  variant?: keyof ReturnType<typeof useMarkerStyles>;
+  variant?: keyof ReturnType<typeof useLiftMarkerStyles>;
   onClick?(event: React.MouseEvent, lift: RomiCore.Lift): void;
 }
 
@@ -120,7 +120,7 @@ export const LiftMarker = React.forwardRef(function (
   const doorMode = liftState ? toDoorMode(liftState) : undefined;
 
   const classes = useStyles();
-  const markerClasses = useMarkerStyles();
+  const markerClasses = useLiftMarkerStyles();
   const markerClass = variant ? markerClasses[variant] : markerClasses.onCurrentFloor;
 
   /**


### PR DESCRIPTION
## What's new

fixes #171

Added style picker according to state priority on lifts.

## Self-checks

- [X] I'm familiar with and follow this [ Typescript guideline](https://basarat.gitbook.io/typescript/styleguide)
- [x] I added unit-tests for new components
- [x] I tried testing edge cases
- [ ] I tested the behavior of the components that interact with the backend, with an e2e test

## Discussion

Should I add tests on the lift-overlay that checks the lift style "business logic"? or a test of the variant on the react-component it's enough? 

I think having both will be great. One to check the component's correct color assignation and the other one to pick the style in the correct order of priority.  