### PR TITLE
fix docker packages from name change

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -60,7 +60,7 @@ jobs:
     needs: build-docker-images
     runs-on: ubuntu-latest
     container:
-      image: docker.pkg.github.com/osrf/romi-dashboard/e2e
+      image: docker.pkg.github.com/osrf/rmf-web/e2e
       credentials:
         username: ${{ github.repository_owner }}
         password: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -39,7 +39,7 @@ jobs:
     name: End-to-End Test
     runs-on: ubuntu-latest
     container:
-      image: docker.pkg.github.com/osrf/romi-dashboard/e2e
+      image: docker.pkg.github.com/osrf/rmf-web/e2e
       credentials:
         username: ${{ github.repository_owner }}
         password: ${{ secrets.GITHUB_TOKEN }}

--- a/packages/dashboard/docker/docker-compose.yml
+++ b/packages/dashboard/docker/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     ports:
       - 8080:8080
   unit-test:
-    image: docker.pkg.github.com/osrf/romi-dashboard/e2e
+    image: docker.pkg.github.com/osrf/rmf-web/e2e
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - ../../..:/root/romi-dashboard
@@ -23,7 +23,7 @@ services:
     # need owner to be root for git ls-remote to work for some reason
     command: bash -c 'npm ci --unsafe-perm && npm run test:coverage'
   dev:
-    image: docker.pkg.github.com/osrf/romi-dashboard/e2e
+    image: docker.pkg.github.com/osrf/rmf-web/e2e
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - ../../..:/root/romi-dashboard

--- a/packages/dashboard/docker/e2e.Dockerfile
+++ b/packages/dashboard/docker/e2e.Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.pkg.github.com/osrf/romi-dashboard/rmf:nightly
+FROM docker.pkg.github.com/osrf/rmf-web/e2e/rmf:nightly
 
 RUN wget -q -O - https://dl.google.com/linux/linux_signing_key.pub | apt-key add - \
   && sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google-chrome.list' \

--- a/packages/dashboard/docker/e2e.Dockerfile
+++ b/packages/dashboard/docker/e2e.Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.pkg.github.com/osrf/rmf-web/e2e/rmf:nightly
+FROM docker.pkg.github.com/osrf/rmf-web/rmf:nightly
 
 RUN wget -q -O - https://dl.google.com/linux/linux_signing_key.pub | apt-key add - \
   && sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google-chrome.list' \

--- a/packages/dashboard/docker/rmf/docker-compose.yml
+++ b/packages/dashboard/docker/rmf/docker-compose.yml
@@ -2,4 +2,4 @@ version: "3"
 services:
   build:
     build: .
-    image: docker.pkg.github.com/osrf/rmf-web/e2e/rmf:nightly
+    image: docker.pkg.github.com/osrf/rmf-web/rmf:nightly

--- a/packages/dashboard/docker/rmf/docker-compose.yml
+++ b/packages/dashboard/docker/rmf/docker-compose.yml
@@ -2,4 +2,4 @@ version: "3"
 services:
   build:
     build: .
-    image: docker.pkg.github.com/osrf/romi-dashboard/rmf:nightly
+    image: docker.pkg.github.com/osrf/rmf-web/e2e/rmf:nightly

--- a/packages/dashboard/e2e/README.md
+++ b/packages/dashboard/e2e/README.md
@@ -19,7 +19,7 @@ Below is a diagram of how the containers and networks interact when up and runni
 
 Broadly speaking, there are 3 major parts of the system:
 
-- Romidashboard container, built from the `docker.pkg.github.com/osrf/rmf-web/e2e/e2e` image with the RMF backend compiled into it. It holds the ROS2 bridge server and the React dashboard. Sourcing of RMF is required before running the tests and it can be sourced from `. /opt/rmf/setup.bash`
+- Romidashboard container, built from the `docker.pkg.github.com/osrf/rmf-web/e2e` image with the RMF backend compiled into it. It holds the ROS2 bridge server and the React dashboard. Sourcing of RMF is required before running the tests and it can be sourced from `. /opt/rmf/setup.bash`
 - Auth container
 - auth_network, a known network where the Auth container is reachable 
 

--- a/packages/dashboard/e2e/README.md
+++ b/packages/dashboard/e2e/README.md
@@ -19,7 +19,7 @@ Below is a diagram of how the containers and networks interact when up and runni
 
 Broadly speaking, there are 3 major parts of the system:
 
-- Romidashboard container, built from the `docker.pkg.github.com/osrf/romi-dashboard/e2e` image with the RMF backend compiled into it. It holds the ROS2 bridge server and the React dashboard. Sourcing of RMF is required before running the tests and it can be sourced from `. /opt/rmf/setup.bash`
+- Romidashboard container, built from the `docker.pkg.github.com/osrf/rmf-web/e2e/e2e` image with the RMF backend compiled into it. It holds the ROS2 bridge server and the React dashboard. Sourcing of RMF is required before running the tests and it can be sourced from `. /opt/rmf/setup.bash`
 - Auth container
 - auth_network, a known network where the Auth container is reachable 
 

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -19,7 +19,7 @@
     "test:coverage": "npm run test -- --coverage --watchAll=false",
     "test:e2e": "cd e2e && npm test",
     "test:e2e:dev": "cd e2e && npm run test:dev",
-    "sync:docker": "docker pull docker.pkg.github.com/osrf/romi-dashboard/e2e && docker pull quay.io/keycloak/keycloak:11.0.0",
+    "sync:docker": "docker pull docker.pkg.github.com/osrf/rmf-web/e2e && docker pull quay.io/keycloak/keycloak:11.0.0",
     "eject": "react-scripts eject",
     "deploy:demo": "REACT_APP_MOCK=1 npm run build && NODE_DEBUG=gh-pages gh-pages -d build -m \"$(git rev-parse HEAD)\"",
     "setup": "node ./scripts/setup/setup.js && node ./scripts/setup/get-icons.js",


### PR DESCRIPTION
## What's new

### [Describe your changes]

Rename docker packages to `rmf-web` after name change from `romi-dashboard`

## Self-checks

- [ ] I'm familiar with and follow this [ Typescript guideline](https://basarat.gitbook.io/typescript/styleguide)
- [ ] I added unit-tests for new components
- [x] I tried testing edge cases
- [ ] I tested the behavior of the components that interact with the backend, with an e2e test

## Discussion

[Questions for reviewers]