### PR TITLE
fix ros2-bridge not exiting on SIGINT

### DIFF
--- a/packages/ros2-bridge/package.json
+++ b/packages/ros2-bridge/package.json
@@ -5,7 +5,7 @@
   "main": "src/index.js",
   "scripts": {
     "preinstall": "node ../../scripts/install.js",
-    "start": "ts-node index.ts",
+    "start": "ts-node src/index.ts",
     "build": "tsc --build",
     "clean": "tsc --build --clean",
     "prepack": "npm ci && npm run clean && npm run build",

--- a/packages/ros2-bridge/src/index.ts
+++ b/packages/ros2-bridge/src/index.ts
@@ -117,6 +117,7 @@ async function main() {
   }
   app.use(rpc.middleware);
 
+  process.on('SIGINT', () => server.close());
   server.listen(config.port, config.host);
 }
 


### PR DESCRIPTION
## What's new

A recent rclnodejs update change the SIGINT behavior to no longer forcefully exit the process, instead it just stops all contexts. The "problem" comes from the fact that because it installs a signal handler, the default nodejs handler no longer gets called so we need to install our own handler to close the server.

## Self-checks

- [x] I'm familiar with and follow this [ Typescript guideline](https://basarat.gitbook.io/typescript/styleguide)
- [ ] I added unit-tests for new components
- [ ] I tried testing edge cases
- [ ] I tested the behavior of the components that interact with the backend, with an e2e test

## Discussion

[Questions for reviewers]