### PR TITLE
fix omnipanel not showing the main menu by default

### DIFF
--- a/packages/dashboard/src/components/dashboard.tsx
+++ b/packages/dashboard/src/components/dashboard.tsx
@@ -66,7 +66,7 @@ export enum OmniPanelViewIndex {
 }
 
 export const mainMenuInitialValues: MainMenuState = {
-  currentView: 1,
+  currentView: 0,
   loading: {
     caption: 'Connecting to api server...',
   },


### PR DESCRIPTION
## What's new

This fixes a recent change that causes the omnipanel to show the doors panel by default instead of the main menu.

## Self-checks

- [x] I'm familiar with and follow this [ Typescript guideline](https://basarat.gitbook.io/typescript/styleguide)
- [ ] I added unit-tests for new components
- [ ] I tried testing edge cases
- [x] I tested the behavior of the components that interact with the backend, with an e2e test

## Discussion

[Questions for reviewers]