### PR TITLE
ros2-bridge: return after the next() call

### DIFF
--- a/packages/ros2-bridge/src/authenticator.ts
+++ b/packages/ros2-bridge/src/authenticator.ts
@@ -20,6 +20,7 @@ export default function authenticator(options: Options): WebSocketMiddleware {
   return (socket: WebSocket & { authorized?: boolean }, data, next) => {
     if (socket.authorized) {
       next();
+      return;
     }
 
     if (typeof data !== 'string') {


### PR DESCRIPTION
## What's new

not quite sure exactly how it affects the middleware chainning. In theory, not returning may cause the authenticator to run checks on data that it is not meant to do.

## Self-checks

- [x] I'm familiar with and follow this [ Typescript guideline](https://basarat.gitbook.io/typescript/styleguide)
- [ ] I added unit-tests for new components
- [ ] I tried testing edge cases
- [x] I tested the behavior of the components that interact with the backend, with an e2e test

## Discussion

[Questions for reviewers]