### PR TITLE
build: always run npm regardless if node_modules is present

### DIFF
--- a/scripts/bootstrap.js
+++ b/scripts/bootstrap.js
@@ -36,16 +36,8 @@ scope.forEach((pkg) => {
 });
 targets.forEach((pkg) => {
   const cwd = `${__dirname}/../${pkg}`;
-  try {
-    fs.accessSync(`${cwd}/node_modules`);
-  } catch (e) {
-    if (e.code === 'ENOENT') {
-      const result = child_process.spawnSync('npm', [verb], { stdio: 'inherit', cwd });
-      if (result.status !== 0) {
-        process.exit(result.status);
-      }
-    } else {
-      throw e;
-    }
+  const result = child_process.spawnSync('npm', [verb], { stdio: 'inherit', cwd });
+  if (result.status !== 0) {
+    process.exit(result.status);
   }
 });


### PR DESCRIPTION
## What's new

this is useful when switching branches or pulling new changes to ensure everything is up to date.

The old behavior is present because it used to be that we recursively install dependent packages, this is no longer the case, we now require the user to manually run bootstrap.

## Self-checks

- [ ] I'm familiar with and follow this [ Typescript guideline](https://basarat.gitbook.io/typescript/styleguide)
- [ ] I added unit-tests for new components
- [ ] I tried testing edge cases
- [ ] I tested the behavior of the components that interact with the backend, with an e2e test

## Discussion

[Questions for reviewers]