### PR TITLE
react-components: prefer ts in storybook

### DIFF
--- a/packages/react-components/.storybook/main.js
+++ b/packages/react-components/.storybook/main.js
@@ -1,4 +1,8 @@
 module.exports = {
   stories: ['../stories/**/*.stories.mdx', '../stories/**/*.stories.@(js|jsx|ts|tsx)'],
   addons: ['@storybook/addon-links', '@storybook/addon-essentials'],
+  webpackFinal: (config) => {
+    config.resolve.extensions = ['.ts', '.tsx', '.mjs', '.js', '.jsx', '.cjs'];
+    return config;
+  },
 };


### PR DESCRIPTION
## What's new

Since `prepare` builds the typescript files, storybook by default uses the js files instead of the ts, this caues hot reload to not work.

## Self-checks

- [ ] I'm familiar with and follow this [ Typescript guideline](https://basarat.gitbook.io/typescript/styleguide)
- [ ] I added unit-tests for new components
- [ ] I tried testing edge cases
- [ ] I tested the behavior of the components that interact with the backend, with an e2e test

## Discussion

[Questions for reviewers]