### PR TITLE
Fixed type problem of tree event by adding tree library`s type

### DIFF
--- a/packages/react-components/lib/task-summary/task-summary-accordion.tsx
+++ b/packages/react-components/lib/task-summary/task-summary-accordion.tsx
@@ -2,7 +2,12 @@ import React from 'react';
 import Debug from 'debug';
 import * as RomiCore from '@osrf/romi-js-core-interfaces';
 import { IconButton, makeStyles, Typography } from '@material-ui/core';
-import { TreeItem, TreeView } from '@material-ui/lab';
+import {
+  MultiSelectTreeViewProps,
+  SingleSelectTreeViewProps,
+  TreeItem,
+  TreeView,
+} from '@material-ui/lab';
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
 import ChevronRightIcon from '@material-ui/icons/ChevronRight';
 import PlayCircleFilledWhiteIcon from '@material-ui/icons/PlayCircleFilledWhite';
@@ -52,11 +57,11 @@ export const TaskSummaryAccordion = React.memo((props: TaskSummaryAccordionProps
   const [expanded, setExpanded] = React.useState<string[]>([]);
   const [selected, setSelected] = React.useState<string>('');
 
-  const handleToggle = (event: React.ChangeEvent<Record<string, unknown>>, nodeIds: string[]) => {
+  const handleToggle: MultiSelectTreeViewProps['onNodeSelect'] = (event, nodeIds) => {
     setExpanded(nodeIds);
   };
 
-  const handleSelect = (event: React.ChangeEvent<Record<string, unknown>>, nodeIds: string) => {
+  const handleSelect: SingleSelectTreeViewProps['onNodeSelect'] = (event, nodeIds) => {
     setSelected(nodeIds);
   };
 


### PR DESCRIPTION
## What's new

Fixed the following problem between the typescript compiler and the typescript linter by using the tree type of material-ui library.
``` bash
../../node_modules/@material-ui/lab/TreeView/TreeView.d.ts:96:3
    96   onNodeSelect?: (event: React.ChangeEvent<{}>, nodeIds: string) => void;
         ~~~~~~~~~~~~
    The expected type comes from property 'onNodeSelect' which is declared here on type '(IntrinsicAttributes & SingleSelectTreeViewProps) | (IntrinsicAttributes & MultiSelectTreeViewProps)'

lib/task-summary/task-summary-accordion.tsx:128:7 - error TS2322: Type '(event: React.ChangeEvent<Record<string, unknown>>, nodeIds: string[]) => void' is not assignable to type '(event: ChangeEvent<{}>, nodeIds: string[]) => void'.
  Types of parameters 'event' and 'event' are incompatible.
    Type 'ChangeEvent<{}>' is not assignable to type 'ChangeEvent<Record<string, unknown>>'.

128       onNodeToggle={handleToggle}
```

## Self-checks

- [X] I'm familiar with and follow this [ Typescript guideline](https://basarat.gitbook.io/typescript/styleguide)
