### PR TITLE
dashboard: change keycloak port to avoid conflict

### DIFF
--- a/packages/dashboard/docker/docker-compose.yml
+++ b/packages/dashboard/docker/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     networks:
       - romi_dashboard_e2e_network
     ports:
-      - 8080:8080
+      - 8088:8080
   unit-test:
     image: docker.pkg.github.com/osrf/rmf-web/e2e
     volumes:

--- a/packages/dashboard/e2e/README.md
+++ b/packages/dashboard/e2e/README.md
@@ -30,7 +30,7 @@ The dashboard would need to be built with the gateway ip address of the `auth_ne
 const authConfig = {
   realm: 'master',
   clientId: 'romi-dashboard',
-  url: `http://${defaultAuthGatewayIp ? defaultAuthGatewayIp : 'localhost'}:8080/auth`,
+  url: `http://${defaultAuthGatewayIp ? defaultAuthGatewayIp : 'localhost'}:8088/auth`,
 };
 process.env.REACT_APP_AUTH_CONFIG = JSON.stringify(authConfig);
 ```

--- a/packages/dashboard/e2e/env.sh
+++ b/packages/dashboard/e2e/env.sh
@@ -3,7 +3,7 @@
 export TS_NODE_PROJECT="${TS_NODE_PROJECT:-tsconfig.json}"
 export REACT_APP_TRAJECTORY_SERVER="${REACT_APP_TRAJECTORY_SERVER:-ws://localhost:8006}"
 export REACT_APP_ROS2_BRIDGE_SERVER="${REACT_APP_ROS2_BRIDGE_SERVER:-ws://localhost:50002}"
-default_auth_config='{ "realm": "master", "clientId": "romi-dashboard", "url": "http://localhost:8080/auth" }'
+default_auth_config='{ "realm": "master", "clientId": "romi-dashboard", "url": "http://localhost:8088/auth" }'
 export REACT_APP_AUTH_CONFIG="${REACT_APP_AUTH_CONFIG:-$default_auth_config}"
 export ROMI_DASHBOARD_PORT="${ROMI_DASHBOARD_PORT:-5000}"
 export COMPOSE_PROJECT_NAME="${COMPOSE_PROJECT_NAME:-romidashboarde2e}"

--- a/packages/dashboard/e2e/scripts/auth-ready.js
+++ b/packages/dashboard/e2e/scripts/auth-ready.js
@@ -15,7 +15,7 @@ async function authReady(timeout = 30000) {
     let retryTimer;
     const waitAuthReady = () => {
       const authIpAddress = process.env.AUTH_GATEWAY_IP;
-      req = http.request(`http://${authIpAddress ? authIpAddress : 'localhost'}:8080/auth/`, () => {
+      req = http.request(`http://${authIpAddress ? authIpAddress : 'localhost'}:8088/auth/`, () => {
         clearTimeout(timer);
         clearTimeout(retryTimer);
         res(true);

--- a/packages/dashboard/e2e/scripts/test-e2e.js
+++ b/packages/dashboard/e2e/scripts/test-e2e.js
@@ -18,7 +18,7 @@ process.env.AUTH_GATEWAY_IP = defaultAuthGatewayIp;
 const authConfig = {
   realm: 'master',
   clientId: 'romi-dashboard',
-  url: `http://${defaultAuthGatewayIp ? defaultAuthGatewayIp : 'localhost'}:8080/auth`,
+  url: `http://${defaultAuthGatewayIp ? defaultAuthGatewayIp : 'localhost'}:8088/auth`,
 };
 process.env.REACT_APP_AUTH_CONFIG = JSON.stringify(authConfig);
 


### PR DESCRIPTION
## What's new

dashboard: change keycloak port to avoid conflict

## Self-checks

- [ ] I'm familiar with and follow this [ Typescript guideline](https://basarat.gitbook.io/typescript/styleguide)
- [ ] I added unit-tests for new components
- [ ] I tried testing edge cases
- [ ] I tested the behavior of the components that interact with the backend, with an e2e test

## Discussion

[Questions for reviewers]