### PR TITLE
dashboard: ScheduleVisualizer now uses the fleet context directly

### DIFF
--- a/packages/dashboard/src/components/dashboard/dashboard.tsx
+++ b/packages/dashboard/src/components/dashboard/dashboard.tsx
@@ -281,7 +281,6 @@ export default function Dashboard(_props: {}): React.ReactElement {
           <ScheduleVisualizer
             buildingMap={buildingMap}
             mapFloorSort={mapFloorSort}
-            fleets={fleets}
             trajManager={trajManager}
             negotiationTrajStore={negotiationTrajStore}
             onDoorClick={handleDoorMarkerClick}

--- a/packages/dashboard/src/components/schedule-visualizer/index.tsx
+++ b/packages/dashboard/src/components/schedule-visualizer/index.tsx
@@ -12,6 +12,7 @@ import {
   Trajectory,
   TrajectoryResponse,
 } from '../../managers/robot-trajectory-manager';
+import { FleetStateContext } from '../rmf-app';
 import { NegotiationTrajectoryResponse } from '../../managers/negotiation-status-manager';
 import { toBlobUrl } from '../../util';
 import { AppControllerContext } from '../app-contexts';
@@ -42,7 +43,6 @@ export interface MapFloorLayer {
 
 export interface ScheduleVisualizerProps extends React.PropsWithChildren<{}> {
   buildingMap: RomiCore.BuildingMap;
-  fleets: RomiCore.FleetState[];
   trajManager?: RobotTrajectoryManager;
   negotiationTrajStore: Readonly<Record<string, NegotiationTrajectoryResponse>>;
   mapFloorSort?(levels: RomiCore.Level[]): string[];
@@ -105,15 +105,18 @@ export default function ScheduleVisualizer(props: ScheduleVisualizerProps): Reac
   );
   const [bound, setBound] = React.useState(initialBounds);
 
+  const fleetStates = React.useContext(FleetStateContext);
+  const fleets = React.useMemo(() => Object.values(fleetStates), [fleetStates]);
+
   const robots = React.useMemo(
     () =>
-      props.fleets.reduce<Record<string, RomiCore.RobotState>>((prev, fleet) => {
+      fleets.reduce<Record<string, RomiCore.RobotState>>((prev, fleet) => {
         fleet.robots.forEach((robot) => {
           prev[robotHash(robot.name, fleet.name)] = robot;
         });
         return prev;
       }, {}),
-    [props.fleets],
+    [fleets],
   );
 
   const trajLookahead = 60000; // 1 min
@@ -379,7 +382,7 @@ export default function ScheduleVisualizer(props: ScheduleVisualizerProps): Reac
               <RobotsOverlay
                 currentFloorName={curLevelName}
                 bounds={curMapFloorLayer.bounds}
-                fleets={props.fleets}
+                fleets={fleets}
                 onRobotClick={props.onRobotClick}
                 conflictRobotNames={conflictRobotNames}
               />


### PR DESCRIPTION
Signed-off-by: Morgan Quigley <morgan@osrfoundation.org>

## What's new

The ScheduleVisualizer component now uses the fleet context directly, rather than receiving it via `props`. Then the parent component doesn't need to render every time the fleet context is updated. This is helpful for the mosaic layout manager (will come in a future PR, currently it's sitting in a branch).

## Self-checks

- [ ] I'm familiar with and follow this [Typescript guideline](https://basarat.gitbook.io/typescript/styleguide)
- [ ] I added unit-tests for new components
- [ ] I tried testing edge cases
- [ ] I tested the behavior of the components that interact with the backend, with an e2e test

## Discussion

<!-- Questions for reviewers, if any -->
