### PR TITLE
dashboard: refactor trajectory manager context into schedule visualizer

### DIFF
--- a/packages/dashboard/src/components/dashboard/dashboard.tsx
+++ b/packages/dashboard/src/components/dashboard/dashboard.tsx
@@ -114,7 +114,6 @@ export default function Dashboard(_props: {}): React.ReactElement {
 
   const transport = React.useContext(TransportContext);
   const buildingMap = React.useContext(BuildingMapContext);
-  const { trajectoryManager: trajManager } = React.useContext(RmfIngressContext);
   const resourceManager = React.useContext(ResourcesContext);
 
   const { state: dashboardState, dispatch: dashboardDispatch } = useDashboardReducer(
@@ -281,7 +280,6 @@ export default function Dashboard(_props: {}): React.ReactElement {
           <ScheduleVisualizer
             buildingMap={buildingMap}
             mapFloorSort={mapFloorSort}
-            trajManager={trajManager}
             negotiationTrajStore={negotiationTrajStore}
             onDoorClick={handleDoorMarkerClick}
             onLiftClick={handleLiftMarkerClick}

--- a/packages/dashboard/src/components/schedule-visualizer/index.tsx
+++ b/packages/dashboard/src/components/schedule-visualizer/index.tsx
@@ -8,7 +8,6 @@ import { AttributionControl, ImageOverlay, LayersControl, Map as LMap, Pane } fr
 import {
   Conflict,
   DefaultTrajectoryManager,
-  RobotTrajectoryManager,
   Trajectory,
   TrajectoryResponse,
 } from '../../managers/robot-trajectory-manager';

--- a/packages/dashboard/src/components/schedule-visualizer/index.tsx
+++ b/packages/dashboard/src/components/schedule-visualizer/index.tsx
@@ -12,7 +12,7 @@ import {
   Trajectory,
   TrajectoryResponse,
 } from '../../managers/robot-trajectory-manager';
-import { FleetStateContext } from '../rmf-app';
+import { FleetStateContext, RmfIngressContext } from '../rmf-app';
 import { NegotiationTrajectoryResponse } from '../../managers/negotiation-status-manager';
 import { toBlobUrl } from '../../util';
 import { AppControllerContext } from '../app-contexts';
@@ -43,7 +43,6 @@ export interface MapFloorLayer {
 
 export interface ScheduleVisualizerProps extends React.PropsWithChildren<{}> {
   buildingMap: RomiCore.BuildingMap;
-  trajManager?: RobotTrajectoryManager;
   negotiationTrajStore: Readonly<Record<string, NegotiationTrajectoryResponse>>;
   mapFloorSort?(levels: RomiCore.Level[]): string[];
   onDoorClick?(door: RomiCore.Door): void;
@@ -107,6 +106,8 @@ export default function ScheduleVisualizer(props: ScheduleVisualizerProps): Reac
 
   const fleetStates = React.useContext(FleetStateContext);
   const fleets = React.useMemo(() => Object.values(fleetStates), [fleetStates]);
+
+  const { trajectoryManager: trajManager } = React.useContext(RmfIngressContext);
 
   const robots = React.useMemo(
     () =>
@@ -182,8 +183,6 @@ export default function ScheduleVisualizer(props: ScheduleVisualizerProps): Reac
   React.useEffect(() => {
     let interval: number;
     (async () => {
-      const trajManager = props.trajManager;
-
       async function updateTrajectory() {
         if (!curMapFloorLayer || !trajManager) {
           return;
@@ -207,7 +206,7 @@ export default function ScheduleVisualizer(props: ScheduleVisualizerProps): Reac
       interval = window.setInterval(updateTrajectory, trajAnimDuration);
     })();
     return () => clearInterval(interval);
-  }, [props.trajManager, curMapFloorLayer, trajAnimDuration]);
+  }, [trajManager, curMapFloorLayer, trajAnimDuration]);
 
   // Show notification when a conflict happens.
   const { showNotification: notificationDispatch } = React.useContext(AppControllerContext);


### PR DESCRIPTION
Signed-off-by: Morgan Quigley <morgan@osrfoundation.org>

## What's new

Moves the trajectory manager context into the `ScheduleVisualizer` component, to continue factoring stuff out of `Dashboard` and into `ScheduleVisualizer` so that it's easier to re-use. Tested in simulation; the trajectory animations still work.

## Self-checks

- [X] I'm familiar with and follow this [Typescript guideline](https://basarat.gitbook.io/typescript/styleguide)
- [ ] I added unit-tests for new components
- [ ] I tried testing edge cases
- [ ] I tested the behavior of the components that interact with the backend, with an e2e test

## Discussion

<!-- Questions for reviewers, if any -->
