### PR TITLE
build: fix error when running bootstrap multiple times

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "root",
   "private": true,
   "scripts": {
-    "install": "python3 -m pipenv install -d --site-packages",
+    "install": "node scripts/pipenv-install.js",
     "bootstrap": "node scripts/bootstrap.js"
   },
   "devDependencies": {

--- a/packages/api-server/pyproject.toml
+++ b/packages/api-server/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta:__legacy__"

--- a/scripts/pipenv-install.js
+++ b/scripts/pipenv-install.js
@@ -1,0 +1,13 @@
+/**
+ * pipenv has a bug? where you get ".project" file not found when running with "--site-packages"
+ * multiple times, it also cleans up the existing venv, removing the .gitignore file.
+ */
+const fs = require('fs');
+const { execSync } = require('child_process');
+
+try {
+  fs.accessSync(`${__dirname}/../.venv/lib`);
+  execSync('python3 -m pipenv install', { stdio: 'inherit' });
+} catch (e) {
+  execSync('python3 -m pipenv install -d --site-packages', { stdio: 'inherit' });
+}


### PR DESCRIPTION
## What's new

<!-- NOTE: Pull request title should be "<package>: <summary>", if the PR affects multiple
  packages, use the main package that it affects. If the PR does not target any specific 
  packages, use general tags like "ci" or "versioning". -->

<!-- uncomment the next line if this PR fixes an issue -->
<!-- fixes #<issue-id> -->

<!-- Describe your changes.

  If your changes affects the UI, show screenshots or videos.

  If your changes affects, or is affected by other RMF components outside of this repo,
  describe how the components interact.

  If your changes fixes a bug, describe the root cause of the bug and how the
  proposed solution fixes it.

  If you went through several iterations while making this PR, explain why you
  prefer the proposed solution.
-->

pipenv has a bug? where you get ".project" file not found when running with "--site-packages" multiple times, it also cleans up the existing venv, removing the .gitignore file.

## Self-checks

- [ ] I'm familiar with and follow this [Typescript guideline](https://basarat.gitbook.io/typescript/styleguide)
- [ ] I added unit-tests for new components
- [ ] I tried testing edge cases
- [ ] I tested the behavior of the components that interact with the backend, with an e2e test

## Discussion

<!-- Questions for reviewers, if any -->
